### PR TITLE
Add accounts list method from Wargaming.net/Accounts section

### DIFF
--- a/gqlclans/logic.py
+++ b/gqlclans/logic.py
@@ -4,6 +4,8 @@ import requests
 
 
 CLAN_INFO = 'https://api.worldoftanks.ru/wgn/clans/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&clan_id={}'
+ACCOUNTS_LIST = 'https://api.worldoftanks.ru/wgn/account/list/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&search={}'
+ACCOUNT_INFO = 'https://api.worldoftanks.ru/wgn/account/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&account_id={}'
 SEARCH_CLAN = 'https://api.worldoftanks.ru/wgn/clans/list/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&fields=clan_id&game=wot&search={}'
 SERVERS_INFO = 'https://api.worldoftanks.ru/wgn/servers/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&game=wot'
 
@@ -33,9 +35,19 @@ def get_clan_info(clan_id):
     return papi_request.session.get(CLAN_INFO.format(clan_id)).json()
 
 
-def search_clan(search_txt):
+def search_accounts(search):
     papi_request = PapiRequestSession()
-    return papi_request.session.get(SEARCH_CLAN.format(search_txt)).json()
+    return papi_request.session.get(ACCOUNTS_LIST.format(search)).json()
+
+
+def get_account_info(account_id):
+    papi_request = PapiRequestSession()
+    return papi_request.session.get(ACCOUNT_INFO.format(account_id)).json()
+
+
+def search_clan(search):
+    papi_request = PapiRequestSession()
+    return papi_request.session.get(SEARCH_CLAN.format(search)).json()
 
 
 def get_servers_info():

--- a/gqlclans/logic.py
+++ b/gqlclans/logic.py
@@ -3,9 +3,8 @@ from collections import defaultdict
 import requests
 
 
-CLAN_INFO = 'https://api.worldoftanks.ru/wgn/clans/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&clan_id={}'
-ACCOUNTS_LIST = 'https://api.worldoftanks.ru/wgn/account/list/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&search={}'
-ACCOUNT_INFO = 'https://api.worldoftanks.ru/wgn/account/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&account_id={}'
+CLAN_INFO = 'https://api.worldoftanks.ru/wgn/clans/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&game=wot&clan_id={}'
+ACCOUNT_INFO = 'https://api.worldoftanks.ru/wot/account/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&account_id={}'
 SEARCH_CLAN = 'https://api.worldoftanks.ru/wgn/clans/list/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&fields=clan_id&game=wot&search={}'
 SERVERS_INFO = 'https://api.worldoftanks.ru/wgn/servers/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&game=wot'
 
@@ -33,11 +32,6 @@ class PapiRequestSession:
 def get_clan_info(clan_id):
     papi_request = PapiRequestSession()
     return papi_request.session.get(CLAN_INFO.format(clan_id)).json()
-
-
-def search_accounts(search):
-    papi_request = PapiRequestSession()
-    return papi_request.session.get(ACCOUNTS_LIST.format(search)).json()
 
 
 def get_account_info(account_id):

--- a/gqlclans/schema.py
+++ b/gqlclans/schema.py
@@ -108,7 +108,7 @@ class Account(graphene.ObjectType):
 
     # Clan members info
     role = graphene.String()
-    # Fields with numbers in names capitalize incorrectly, https://github.com/graphql-python/graphene/issues/643
+    # Fields with numbers in names capitalize incorrectly, will be fixed in graphene 2.0.2
     # role_i18n = graphene.String()
     joined_at = graphene.Int()
     clan = graphene.Field(lambda: Clan)

--- a/gqlclans/utils.py
+++ b/gqlclans/utils.py
@@ -26,8 +26,7 @@ def collect_fields(node, fragments):
                     leaf['name']['value']: collect_fields(leaf, fragments)
                 })
             elif leaf['kind'] == 'FragmentSpread':
-                field.update(collect_fields(fragments[leaf['name']['value']],
-                                            fragments))
+                field.update(collect_fields(fragments[leaf['name']['value']], fragments))
 
     return field
 

--- a/gqlclans/utils.py
+++ b/gqlclans/utils.py
@@ -1,0 +1,49 @@
+# https://gist.github.com/mixxorz/dc36e180d1888629cf33
+
+from graphql.utils.ast_to_dict import ast_to_dict
+
+
+def collect_fields(node, fragments):
+    """Recursively collects fields from the AST
+    Args:
+        node (dict): A node in the AST
+        fragments (dict): Fragment definitions
+    Returns:
+        A dict mapping each field found, along with their sub fields.
+        {'name': {},
+         'sentimentsPerLanguage': {'id': {},
+                                   'name': {},
+                                   'totalSentiments': {}},
+         'slug': {}}
+    """
+
+    field = {}
+
+    if node.get('selection_set'):
+        for leaf in node['selection_set']['selections']:
+            if leaf['kind'] == 'Field':
+                field.update({
+                    leaf['name']['value']: collect_fields(leaf, fragments)
+                })
+            elif leaf['kind'] == 'FragmentSpread':
+                field.update(collect_fields(fragments[leaf['name']['value']],
+                                            fragments))
+
+    return field
+
+
+def get_fields(info):
+    """A convenience function to call collect_fields with info
+    Args:
+        info (ResolveInfo)
+    Returns:
+        dict: Returned from collect_fields
+    """
+
+    fragments = {}
+    node = ast_to_dict(info.field_asts[0])
+
+    for name, value in info.fragments.items():
+        fragments[name] = ast_to_dict(value)
+
+    return collect_fields(node, fragments)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 aiohttp
+aiohttp-devtools
 aiohttp-graphql
-aiohttp-utils
 graphene
 requests
 pytest
 pytest-mock
 pytest-aiohttp
+stringcase

--- a/start_app.py
+++ b/start_app.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
-from aiohttp_utils import run
+from aiohttp import web
 
 from gqlclans.app import app
 
-
 if __name__ == '__main__':
-    run(app, app_uri='gqlclans.app:app', port=8567, reload=True)
+    web.run_app(app, port=8567)

--- a/tests/test_gqlclans.py
+++ b/tests/test_gqlclans.py
@@ -6,60 +6,105 @@ from gqlclans.schema import schema
 from gqlclans.app import app
 
 
-def test_clan():
+MOCKED_CLAN_INFO_RESPONSE = {
+    'status': 'ok',
+    'data': {
+        '12344': {
+            'clan_id': 12344,
+            'name': 'Mocked Name',
+            'tag': 'MCKD',
+            'color': '000000',
+            'members': [{
+                'account_name': f'Account-{i}',
+                'account_id': i,
+                'role': 'private',
+            } for i in range(5)]
+        }
+    }
+}
+
+MOCKED_CLAN_SEARCH_RESPONSE = {
+    'status': 'ok',
+    'data': [
+        {
+            'clan_id': 12344,
+            'name': 'Mocked Name 12344',
+            'tag': 'MCKD 12344',
+            'color': '000000',
+        },
+        {
+            'clan_id': 10000,
+            'name': 'Mocked Name 10000',
+            'tag': 'MCKD 10000',
+            'color': '000000',
+        },
+    ]
+}
+
+MOCKED_SERVERS_INFO_RESPONSE = {
+    'status': 'ok',
+    'data': {
+        'wot': [{
+            'players_online': i * 100,
+            'server': f'RU{i}',
+        } for i in range(8)]
+    }
+}
+
+
+def test_clan(mocker):
+    mocker.patch('gqlclans.logic.get_clan_info', return_value=MOCKED_CLAN_INFO_RESPONSE)
     query = '{ clans(clanId: "10164") { tag name }}'
     client = Client(schema)
     result = client.execute(query)
-    assert result == {
-        'data': {
-            'clans': [
-                {
-                    'tag': 'BOUHA',
-                    'name': 'Второй  всадник  апокалипсиса',
-                }
-            ]
+    assert result['data']['clans'] == [
+        {
+            'tag': 'MCKD',
+            'name': 'Mocked Name',
         }
-    }
+    ]
 
 
-def test_servers():
+def test_servers(mocker):
+    mocker.patch('gqlclans.logic.get_servers_info', return_value=MOCKED_SERVERS_INFO_RESPONSE)
     query = '{ servers(limit: 2) { server playersOnline }}'
     client = Client(schema)
     result = client.execute(query)
-    assert result == {
-        'data': {
-            'servers': [
-                {
-                    'playersOnline': 14583,
-                    'server': 'RU8',
-                },
-                {
-                    'playersOnline': 37041,
-                    'server': 'RU7',
-                }
-            ]
+    assert result['data']['servers'] == [
+        {
+            'playersOnline': 0,
+            'server': 'RU0',
+        },
+        {
+            'playersOnline': 100,
+            'server': 'RU1',
         }
-    }
+    ]
 
 
-def test_search():
-    query = '{ search(searchTxt: "BOUHA") { tag name }}'
+def test_search(mocker):
+    mocker.patch('gqlclans.logic.search_clan', return_value={
+        'data': [{'clan_id': '12345'}, {'clan_id': '10000'}]
+    })
+    mocker.patch('gqlclans.logic.get_clan_info', return_value={
+        'data': {
+            '12345': {'name': 'Mocked Name 12344', 'tag': 'MCKD 12344', 'members': [], 'clan_id': 12345, 'color': ''},
+            '10000': {'name': 'Mocked Name 10000', 'tag': 'MCKD 10000', 'members': [], 'clan_id': 10000, 'color': ''},
+        }
+    })
+    query = '{ searchClans(search: "BOUHA") { tag name }}'
     client = Client(schema)
     result = client.execute(query)
-    assert result == {
-        'data': {
-            'search': [
-                {
-                    'tag': 'BETH',
-                    'name': 'BouHa',
-                },
-                {
-                    'tag': 'BOUHA',
-                    'name': 'Второй  всадник  апокалипсиса',
-                },
-            ]
-        }
-    }
+    assert result['data']['searchClans'] == [
+        {
+            'tag': 'MCKD 12344',
+            'name': 'Mocked Name 12344',
+        },
+        {
+            'tag': 'MCKD 10000',
+            'name': 'Mocked Name 10000',
+        },
+    ]
 
 
 def test_mutation():
@@ -88,6 +133,7 @@ def test_mutation():
 
 
 def test_batch_loading_cache(mocker):
+    mocked_clan_info = mocker.patch('gqlclans.logic.get_clan_info', return_value=MOCKED_CLAN_INFO_RESPONSE)
     query = '''{
         clans(clanId: "12344") {
             members {
@@ -98,40 +144,22 @@ def test_batch_loading_cache(mocker):
         }
     }
     '''
-    mocked_clan_info_response = {
-        'data': {
-            '12344': {
-                'clan_id': 12344,
-                'name': 'Mocked Name',
-                'tag': 'MCKD',
-                'color': '000000',
-                'members': [{
-                    'account_name': f'Account-{i}',
-                    'account_id': i,
-                    'role': 'private',
-                } for i in range(5)]
-            }
-        }
-    }
-    mocked_clan_info = mocker.patch('gqlclans.logic.get_clan_info', return_value=mocked_clan_info_response)
 
     client = Client(schema)
     result = client.execute(query)
     assert len(mocked_clan_info.mock_calls) == 2
-    assert result == {
-        'data': {
-            'clans': [{
-                'members': [{
-                    'clan': {
-                        'clanId': '12344',
-                    }
-                } for _ in range(5)]
-            }]
-        },
-    }
+    assert result['data']['clans'] == [{
+        'members': [{
+            'clan': {
+                'clanId': '12344',
+            }
+        } for _ in range(5)]
+    }]
 
 
-async def test_app(test_client):
+async def test_app(test_client, mocker):
+    mocker.patch('gqlclans.logic.get_clan_info', return_value=MOCKED_CLAN_INFO_RESPONSE)
+
     client = await test_client(app)
     response = await client.get('/?query={clans{name tag}}')
     assert response.history[0].status == 307
@@ -143,6 +171,6 @@ async def test_app(test_client):
     content = await response.content.read()
     assert json.loads(content) == {
         'data': {
-            'clans': [{'tag': 'BOUHA', 'name': 'Второй  всадник  апокалипсиса'}]
+            'clans': [{'tag': 'MCKD', 'name': 'Mocked Name'}]
         }
     }


### PR DESCRIPTION
Add account info endpoint and merge data which this API provides with clan members info. Also add helper function which gives a dictionary of requested fields in resolvers. This function made it possible to decide, which fields are needed and make requests only for them. For example, if we make query like
```
query accounts(accountIds: ["12345"]) {
    nickname
    createdAt
}
```
we can determine that in our query there aren't fields which are specific only for clan info data, so we can do only one request to `account/info`

The code could seem tricky, but it solves the issue. The main moment is that graphene camelcases every field in nodes, but out API returns data with keys in snakecase, so we have to dance around it with `snakecase()` and `camelcase()` functions. In future we'll have a better architecture for load balancing and solving the problems how to load and combine data, I hope.

Also, because of  members in clan info method have `account_name` field, which is completely the same as `nickname`  in account info method I was forced to add workaround which add to result `nickname` field either `account_name` value or `nickname` value