### PR TITLE
#16 Configuration for grahpql service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 .idea
 .DS_Store
+
+# Settings
+settings_local.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM python:3.6
 
-RUN mkdir /src
-WORKDIR /src
-
-COPY requirements.txt requirements.txt
+COPY requirements.txt /src/requirements.txt
 RUN pip install tox && \
-    pip install -r requirements.txt
+    pip install -r /src/requirements.txt
 
+WORKDIR /src
 COPY scripts/start.sh start.sh
-COPY ./start_app.py ./tox.ini /src/
+COPY ./start_app.py ./tox.ini ./init_settings.py ./settings.py /src/
 COPY tests tests
 COPY gqlclans gqlclans
+
+RUN python ./init_settings.py -s "os.environ.get('WGAPI_APPLICATION_ID')"
 
 EXPOSE 8567
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Install python packages in virtualenv:
 
 # Usage
 
+Generate settings
+
+    ```
+    python ./scripts/init_settings.py <WGAPI_APPLICATION_ID>
+    ```
+
 To run http server command:
 
     ```
@@ -25,7 +31,7 @@ Now you can visit [http://localhost:8567](http://localhost:8567) and play with G
 To run backend container from docker:
 
     ```
-    docker create --name=gqlclans -t -i -p 8567:8567 sudoaptget/gqlclans:latest
+    docker create --name=gqlclans -t -i -p 8567:8567 sudoaptget/gqlclans:latest -e WGAPI_APPLICATION_ID=<WGAPI_APPLICATION_ID>
     docker start -i gqlclans
     ```
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,5 @@
 sut:
   build: .
   command: tox
+  environment:
+    WGAPI_APPLICATION_ID: "8c2d3111d4e93eaa2a6e008424123d6d"

--- a/gqlclans/logic.py
+++ b/gqlclans/logic.py
@@ -3,9 +3,13 @@ from collections import defaultdict
 import requests
 
 
-CLAN_INFO = 'https://api.worldoftanks.ru/wgn/clans/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&clan_id={}'
-SEARCH_CLAN = 'https://api.worldoftanks.ru/wgn/clans/list/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&fields=clan_id&game=wot&search={}'
-SERVERS_INFO = 'https://api.worldoftanks.ru/wgn/servers/info/?application_id=8c2d3111d4e93eaa2a6e008424123d6d&game=wot'
+import settings
+
+
+CLAN_INFO = 'https://api.worldoftanks.ru/wgn/clans/info/?application_id=%s&clan_id={}' % settings.WGAPI_APPLICATION_ID
+SEARCH_CLAN = 'https://api.worldoftanks.ru/wgn/clans/list/?application_id=%s&fields=clan_id&game=wot&search={}' % settings.WGAPI_APPLICATION_ID
+SERVERS_INFO = 'https://api.worldoftanks.ru/wgn/servers/info/?application_id=%s&game=wot' % settings.WGAPI_APPLICATION_ID
+
 
 
 __all__ = (

--- a/gqlclans/schema.py
+++ b/gqlclans/schema.py
@@ -3,6 +3,7 @@ from promise import Promise
 from promise.dataloader import DataLoader
 
 from gqlclans import logic
+import settings
 
 
 class ClanLoader(DataLoader):
@@ -70,7 +71,7 @@ class Mutation(graphene.ObjectType):
 
 
 class Query(graphene.ObjectType):
-    clans = graphene.Field(graphene.List(Clan), clan_id=graphene.String(default_value='20226'))
+    clans = graphene.Field(graphene.List(Clan), clan_id=graphene.String(default_value=settings.DEFAULT_CLAN_ID))
     search = graphene.Field(graphene.List(Clan), search_txt=graphene.String(default_value=''))
     servers = graphene.Field(graphene.List(ServerInfo), limit=graphene.Int(default_value=10))
 

--- a/scripts/init_settings.py
+++ b/scripts/init_settings.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""
+Generate settings_local
+"""
+import argparse
+import os
+import sys
+from functools import partial
+
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OUTPUT_FILE_NAME = os.path.join(BASE_DIR, 'settings_local.py')
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('wgapi_application_id', type=str,
+                    help='Application ID (https://developers.wargaming.net/applications/ )')
+parser.add_argument('-s', '--silent', action='store_true',
+                    help='Silently exit if settings_local exists')
+parser.add_argument('-o', '--output', type=str,
+                    help='Output file',
+                    default=OUTPUT_FILE_NAME)
+parser.add_argument('-f', '--force', action='store_true',
+                    help='Rewrite exist settings')
+
+
+def main():
+    args = parser.parse_args()
+    error = partial(exit_and_print_error, args.silent)
+    if not args.force and os.path.isfile(args.output):
+        error('%s already exists. Use --force to override this file' % args.output)
+    config = generate_settings_file(args)
+    with open(args.output, 'w') as output_file:
+        output_file.write(config)
+
+
+def exit_and_print_error(silent, error_text):
+    if silent:
+        exit(0)
+    else:
+        print(error_text, file=sys.stderr)
+
+
+def generate_settings_file(args):
+    template = """import os
+
+
+WGAPI_APPLICATION_ID = %(application_id)s
+"""
+    return template % {
+        'application_id': format_arg(args.wgapi_application_id)
+    }
+
+
+def format_arg(value):
+    if value.startswith('os.environ.get'):
+        return value
+    else:
+        return '\'%s\'' % value
+
+
+if __name__ == '__main__':
+    main()

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,9 @@
+import sys
+
+
+DEFAULT_CLAN_ID = '20226'
+
+try:
+    from settings_local import *
+except ImportError:
+    print('settings_local is not provided', file=sys.stderr)

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=py36
 skipsdist=True
 [testenv]
+passenv = *
 deps=
       -rrequirements.txt
       pytest


### PR DESCRIPTION
Added file `settings.py` and command `init_settings.py` for generate `settings_local.py`

Docker use env values to override settings.

Should we also add local (ignored in git) configuration for `docker_compose.test.yml` in order to remove `WGAPI_APPLICATION_ID` from repo? What do you think?